### PR TITLE
Ignore VSCode files and dirs, enter GPG key password on mvn install s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 *.iml
 target/**
 .DS_Store
+
+# VSCode directories and files
+.classpath
+.vscode/
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.mastercard.developer</groupId>
     <artifactId>oauth1-signer</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Zero dependency library for generating a Mastercard API compliant OAuth signature</description>
     <url>https://github.com/Mastercard/oauth1-signer-java</url>
@@ -147,10 +147,6 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
                             <skip>${gpg.signature.skip}</skip>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.mastercard.developer</groupId>
     <artifactId>oauth1-signer</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Zero dependency library for generating a Mastercard API compliant OAuth signature</description>
     <url>https://github.com/Mastercard/oauth1-signer-java</url>
@@ -147,6 +147,10 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
                             <skip>${gpg.signature.skip}</skip>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Updates so mvn install doesn't fail.  It was failing on the mvn-gpg-plugin step.  This PR adds arguments that asks the user for a GPG password, so it assumes that the user has a GPG key on their system with a password.  Hasn't been tested with a GPG key without a password.