### PR TITLE
Added a signer for Spring HTTP requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <name>oauth1-signer</name>
 
     <properties>
+        <spring-version>5.1.9.RELEASE</spring-version>
         <okhttp2-version>2.7.5</okhttp2-version>
         <okhttp3-version>3.12.0</okhttp3-version>
         <google-api-client-version>1.23.0</google-api-client-version>
@@ -53,6 +54,12 @@
     </distributionManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring-version}</version>
+        </dependency>
+        
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${spring-version}</version>
+            <scope>provided</scope>
         </dependency>
         
         <dependency>

--- a/src/main/java/com/mastercard/developer/signers/SpringHttpRequestSigner.java
+++ b/src/main/java/com/mastercard/developer/signers/SpringHttpRequestSigner.java
@@ -1,0 +1,41 @@
+package com.mastercard.developer.signers;
+
+import com.mastercard.developer.oauth.OAuth;
+
+import java.nio.charset.Charset;
+import java.security.PrivateKey;
+
+import org.springframework.http.HttpMessage;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+/**
+ * Utility class for signing Spring RestTemplate requests.
+ */
+public class SpringHttpRequestSigner extends AbstractSigner {
+    
+  public SpringHttpRequestSigner(String consumerKey, PrivateKey signingKey) {
+    super(consumerKey, signingKey);
+  }
+
+  public void sign(HttpRequest request, byte[] bytes) {
+    HttpHeaders headers = request.getHeaders();
+    Charset charset = getCharset(headers);
+    String payload = new String(bytes, charset);
+    String authHeader = OAuth.getAuthorizationHeader(request.getURI(), request.getMethod().toString(), payload, charset, consumerKey, signingKey);
+    headers.add(OAuth.AUTHORIZATION_HEADER_NAME, authHeader);
+  }
+  
+  private static Charset getCharset(HttpHeaders headers){
+    Charset defaultCharset = Charset.defaultCharset();
+    MediaType contentType = headers.getContentType();
+    if(contentType != null){
+      Charset charset = contentType.getCharset();
+      if(charset != null){
+        return charset;
+      }
+    }
+    return defaultCharset;
+  }
+}

--- a/src/main/java/com/mastercard/developer/signers/SpringHttpRequestSigner.java
+++ b/src/main/java/com/mastercard/developer/signers/SpringHttpRequestSigner.java
@@ -5,7 +5,6 @@ import com.mastercard.developer.oauth.OAuth;
 import java.nio.charset.Charset;
 import java.security.PrivateKey;
 
-import org.springframework.http.HttpMessage;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -22,7 +21,7 @@ public class SpringHttpRequestSigner extends AbstractSigner {
     public void sign(HttpRequest request, byte[] bytes) {
         HttpHeaders headers = request.getHeaders();
         Charset charset = getCharset(headers);
-        String payload = new String(bytes, charset);
+        String payload = (null==bytes ? null : new String(bytes, charset));
         String authHeader = OAuth.getAuthorizationHeader(request.getURI(), request.getMethod().toString(), payload, charset, consumerKey, signingKey);
         headers.add(OAuth.AUTHORIZATION_HEADER_NAME, authHeader);
     }

--- a/src/main/java/com/mastercard/developer/signers/SpringHttpRequestSigner.java
+++ b/src/main/java/com/mastercard/developer/signers/SpringHttpRequestSigner.java
@@ -15,27 +15,27 @@ import org.springframework.http.MediaType;
  */
 public class SpringHttpRequestSigner extends AbstractSigner {
     
-  public SpringHttpRequestSigner(String consumerKey, PrivateKey signingKey) {
-    super(consumerKey, signingKey);
-  }
-
-  public void sign(HttpRequest request, byte[] bytes) {
-    HttpHeaders headers = request.getHeaders();
-    Charset charset = getCharset(headers);
-    String payload = new String(bytes, charset);
-    String authHeader = OAuth.getAuthorizationHeader(request.getURI(), request.getMethod().toString(), payload, charset, consumerKey, signingKey);
-    headers.add(OAuth.AUTHORIZATION_HEADER_NAME, authHeader);
-  }
-  
-  private static Charset getCharset(HttpHeaders headers){
-    Charset defaultCharset = Charset.defaultCharset();
-    MediaType contentType = headers.getContentType();
-    if(contentType != null){
-      Charset charset = contentType.getCharset();
-      if(charset != null){
-        return charset;
-      }
+    public SpringHttpRequestSigner(String consumerKey, PrivateKey signingKey) {
+        super(consumerKey, signingKey);
     }
-    return defaultCharset;
-  }
+    
+    public void sign(HttpRequest request, byte[] bytes) {
+        HttpHeaders headers = request.getHeaders();
+        Charset charset = getCharset(headers);
+        String payload = new String(bytes, charset);
+        String authHeader = OAuth.getAuthorizationHeader(request.getURI(), request.getMethod().toString(), payload, charset, consumerKey, signingKey);
+        headers.add(OAuth.AUTHORIZATION_HEADER_NAME, authHeader);
+    }
+    
+    private static Charset getCharset(HttpHeaders headers){
+        Charset defaultCharset = Charset.defaultCharset();
+        MediaType contentType = headers.getContentType();
+        if(contentType != null){
+            Charset charset = contentType.getCharset();
+            if(charset != null){
+                return charset;
+            }
+        }
+        return defaultCharset;
+    }
 }

--- a/src/test/java/com/mastercard/developer/signers/SpringHttpRequestSignerTest.java
+++ b/src/test/java/com/mastercard/developer/signers/SpringHttpRequestSignerTest.java
@@ -1,0 +1,94 @@
+package com.mastercard.developer.signers;
+
+import com.mastercard.developer.test.TestUtils;
+
+import org.springframework.http.HttpMessage;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import java.net.URI;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.PrivateKey;
+
+public class SpringHttpRequestSignerTest {
+    
+    private static final HttpMethod method = HttpMethod.POST;
+    private static final String body = "{\"foo\":\"bar\"}";
+    private static final String consumerKey = "Some key";
+    
+    private PrivateKey signingKey;
+	private URI uri;
+    private HttpHeaders headers;
+    private HttpRequest request;
+    
+    @Before 
+    public void initialize() throws Exception {
+    
+        signingKey = TestUtils.getTestSigningKey();
+        uri = new URI("https://api.mastercard.com/service");
+        headers = new HttpHeaders();
+        request = new HttpRequest() {
+            public HttpMethod getMethod(){
+                return method;
+            }
+            public String getMethodValue(){
+                return getMethod().toString();
+            }
+            public URI getURI(){
+                return uri;
+            }
+            public HttpHeaders getHeaders(){
+                return headers;
+            }
+        };
+    }
+
+    @Test
+    public void testSign_ShouldAddOAuth1HeaderToPostRequest() throws Exception {
+
+        // WHEN
+        SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
+        instanceUnderTest.sign(request, body.getBytes());
+
+        // THEN
+        String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+        Assert.assertNotNull(authorizationHeaderValue);
+    }
+    
+    @Test
+    public void testSign_ShouldAddOAuth1HeaderToPostRequestWithCharset() throws Exception {
+
+        // GIVEN
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+
+        // WHEN
+        SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
+        instanceUnderTest.sign(request, body.getBytes());
+
+        // THEN
+        String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+        Assert.assertNotNull(authorizationHeaderValue);
+    }
+
+    @Test
+    public void testSign_ShouldAddOAuth1HeaderToPostRequestWithInvalidCharset() throws Exception {
+
+        // GIVEN
+        headers.setContentType(MediaType.APPLICATION_PDF);
+
+        // WHEN
+        SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
+        instanceUnderTest.sign(request, body.getBytes());
+
+        // THEN
+        String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+        Assert.assertNotNull(authorizationHeaderValue);
+    }
+
+}

--- a/src/test/java/com/mastercard/developer/signers/SpringHttpRequestSignerTest.java
+++ b/src/test/java/com/mastercard/developer/signers/SpringHttpRequestSignerTest.java
@@ -17,78 +17,78 @@ import org.junit.Test;
 import java.security.PrivateKey;
 
 public class SpringHttpRequestSignerTest {
-    
-    private static final HttpMethod method = HttpMethod.POST;
-    private static final String body = "{\"foo\":\"bar\"}";
-    private static final String consumerKey = "Some key";
-    
-    private PrivateKey signingKey;
+	
+	private static final HttpMethod method = HttpMethod.POST;
+	private static final String body = "{\"foo\":\"bar\"}";
+	private static final String consumerKey = "Some key";
+	
+	private PrivateKey signingKey;
 	private URI uri;
-    private HttpHeaders headers;
-    private HttpRequest request;
-    
-    @Before 
-    public void initialize() throws Exception {
-    
-        signingKey = TestUtils.getTestSigningKey();
-        uri = new URI("https://api.mastercard.com/service");
-        headers = new HttpHeaders();
-        request = new HttpRequest() {
-            public HttpMethod getMethod(){
-                return method;
-            }
-            public String getMethodValue(){
-                return getMethod().toString();
-            }
-            public URI getURI(){
-                return uri;
-            }
-            public HttpHeaders getHeaders(){
-                return headers;
-            }
-        };
-    }
-
-    @Test
-    public void testSign_ShouldAddOAuth1HeaderToPostRequest() throws Exception {
-
-        // WHEN
-        SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
-        instanceUnderTest.sign(request, body.getBytes());
-
-        // THEN
-        String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
-        Assert.assertNotNull(authorizationHeaderValue);
-    }
-    
-    @Test
-    public void testSign_ShouldAddOAuth1HeaderToPostRequestWithCharset() throws Exception {
-
-        // GIVEN
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-
-        // WHEN
-        SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
-        instanceUnderTest.sign(request, body.getBytes());
-
-        // THEN
-        String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
-        Assert.assertNotNull(authorizationHeaderValue);
-    }
-
-    @Test
-    public void testSign_ShouldAddOAuth1HeaderToPostRequestWithInvalidCharset() throws Exception {
-
-        // GIVEN
-        headers.setContentType(MediaType.APPLICATION_PDF);
-
-        // WHEN
-        SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
-        instanceUnderTest.sign(request, body.getBytes());
-
-        // THEN
-        String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
-        Assert.assertNotNull(authorizationHeaderValue);
-    }
+	private HttpHeaders headers;
+	private HttpRequest request;
+	
+	@Before 
+	public void initialize() throws Exception {
+	
+		signingKey = TestUtils.getTestSigningKey();
+		uri = new URI("https://api.mastercard.com/service");
+		headers = new HttpHeaders();
+		request = new HttpRequest() {
+			public HttpMethod getMethod(){
+				return method;
+			}
+			public String getMethodValue(){
+				return getMethod().toString();
+			}
+			public URI getURI(){
+				return uri;
+			}
+			public HttpHeaders getHeaders(){
+				return headers;
+			}
+		};
+	}
+	
+	@Test
+	public void testSign_ShouldAddOAuth1HeaderToPostRequest() throws Exception {
+	
+		// WHEN
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
+		instanceUnderTest.sign(request, body.getBytes());
+		
+		// THEN
+		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+		Assert.assertNotNull(authorizationHeaderValue);
+	}
+	
+	@Test
+	public void testSign_ShouldAddOAuth1HeaderToPostRequestWithCharset() throws Exception {
+	
+		// GIVEN
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		
+		// WHEN
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
+		instanceUnderTest.sign(request, body.getBytes());
+		
+		// THEN
+		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+		Assert.assertNotNull(authorizationHeaderValue);
+	}
+	
+	@Test
+	public void testSign_ShouldAddOAuth1HeaderToPostRequestWithInvalidCharset() throws Exception {
+	
+		// GIVEN
+		headers.setContentType(MediaType.APPLICATION_PDF);
+		
+		// WHEN
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
+		instanceUnderTest.sign(request, body.getBytes());
+		
+		// THEN
+		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+		Assert.assertNotNull(authorizationHeaderValue);
+	}
 
 }

--- a/src/test/java/com/mastercard/developer/signers/SpringHttpRequestSignerTest.java
+++ b/src/test/java/com/mastercard/developer/signers/SpringHttpRequestSignerTest.java
@@ -2,7 +2,6 @@ package com.mastercard.developer.signers;
 
 import com.mastercard.developer.test.TestUtils;
 
-import org.springframework.http.HttpMessage;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -18,9 +17,10 @@ import java.security.PrivateKey;
 
 public class SpringHttpRequestSignerTest {
 	
-	private static final HttpMethod method = HttpMethod.POST;
-	private static final String body = "{\"foo\":\"bar\"}";
-	private static final String consumerKey = "Some key";
+	private static final HttpMethod POST_METHOD = HttpMethod.POST;
+	private static final HttpMethod GET_METHOD = HttpMethod.GET;
+	private static final String DEFAULT_BODY = "{\"foo\":\"bar\"}";
+	private static final String DEFAULT_CONSUMER_KEY = "Some key";
 	
 	private PrivateKey signingKey;
 	private URI uri;
@@ -34,15 +34,19 @@ public class SpringHttpRequestSignerTest {
 		uri = new URI("https://api.mastercard.com/service");
 		headers = new HttpHeaders();
 		request = new HttpRequest() {
+			@Override
 			public HttpMethod getMethod(){
-				return method;
+				return POST_METHOD;
 			}
+			@Override
 			public String getMethodValue(){
 				return getMethod().toString();
 			}
+			@Override
 			public URI getURI(){
 				return uri;
 			}
+			@Override
 			public HttpHeaders getHeaders(){
 				return headers;
 			}
@@ -50,11 +54,11 @@ public class SpringHttpRequestSignerTest {
 	}
 	
 	@Test
-	public void testSign_ShouldAddOAuth1HeaderToPostRequest() throws Exception {
+	public void testSignShouldAddOAuth1HeaderToPostRequest() {
 	
 		// WHEN
-		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
-		instanceUnderTest.sign(request, body.getBytes());
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(DEFAULT_CONSUMER_KEY, signingKey);
+		instanceUnderTest.sign(request, DEFAULT_BODY.getBytes());
 		
 		// THEN
 		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
@@ -62,14 +66,14 @@ public class SpringHttpRequestSignerTest {
 	}
 	
 	@Test
-	public void testSign_ShouldAddOAuth1HeaderToPostRequestWithCharset() throws Exception {
+	public void testSignShouldAddOAuth1HeaderToPostRequestWithCharset() {
 	
 		// GIVEN
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
 		
 		// WHEN
-		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
-		instanceUnderTest.sign(request, body.getBytes());
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(DEFAULT_CONSUMER_KEY, signingKey);
+		instanceUnderTest.sign(request, DEFAULT_BODY.getBytes());
 		
 		// THEN
 		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
@@ -77,14 +81,78 @@ public class SpringHttpRequestSignerTest {
 	}
 	
 	@Test
-	public void testSign_ShouldAddOAuth1HeaderToPostRequestWithInvalidCharset() throws Exception {
+	public void testSignShouldAddOAuth1HeaderToPostRequestWithInvalidCharset() {
 	
 		// GIVEN
 		headers.setContentType(MediaType.APPLICATION_PDF);
 		
 		// WHEN
-		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(consumerKey, signingKey);
-		instanceUnderTest.sign(request, body.getBytes());
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(DEFAULT_CONSUMER_KEY, signingKey);
+		instanceUnderTest.sign(request, DEFAULT_BODY.getBytes());
+		
+		// THEN
+		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+		Assert.assertNotNull(authorizationHeaderValue);
+	}
+
+	@Test
+	public void testSignShouldAddOAuth1HeaderToGetRequestNullBody() {
+	
+		// GIVEN
+		request = new HttpRequest() {
+			@Override
+			public HttpMethod getMethod(){
+				return GET_METHOD;
+			}
+			@Override
+			public String getMethodValue(){
+				return getMethod().toString();
+			}
+			@Override
+			public URI getURI(){
+				return uri;
+			}
+			@Override
+			public HttpHeaders getHeaders(){
+				return headers;
+			}
+		};
+
+		// WHEN
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(DEFAULT_CONSUMER_KEY, signingKey);
+		instanceUnderTest.sign(request, null);
+		
+		// THEN
+		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);
+		Assert.assertNotNull(authorizationHeaderValue);
+	}
+
+	@Test
+	public void testSignShouldAddOAuth1HeaderToGetRequestEmptyBody() {
+	
+		// GIVEN
+		request = new HttpRequest() {
+			@Override
+			public HttpMethod getMethod(){
+				return GET_METHOD;
+			}
+			@Override
+			public String getMethodValue(){
+				return getMethod().toString();
+			}
+			@Override
+			public URI getURI(){
+				return uri;
+			}
+			@Override
+			public HttpHeaders getHeaders(){
+				return headers;
+			}
+		};
+
+		// WHEN
+		SpringHttpRequestSigner instanceUnderTest = new SpringHttpRequestSigner(DEFAULT_CONSUMER_KEY, signingKey);
+		instanceUnderTest.sign(request, "".getBytes());
 		
 		// THEN
 		String authorizationHeaderValue = headers.getFirst(HttpHeaders.AUTHORIZATION);


### PR DESCRIPTION
Added a new signer for Spring HTTP requests. The class can be used by a org.springframework.http.client.ClientHttpRequestInterceptor for signing requests before thet are sent.