### PR TITLE
Adding more util method to read the cert file from a stream

### DIFF
--- a/src/main/java/com/mastercard/developer/utils/AuthenticationUtils.java
+++ b/src/main/java/com/mastercard/developer/utils/AuthenticationUtils.java
@@ -1,6 +1,7 @@
 package com.mastercard.developer.utils;
 
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.security.*;
 import java.security.cert.CertificateException;
@@ -19,8 +20,16 @@ public final class AuthenticationUtils {
     public static PrivateKey loadSigningKey(String pkcs12KeyFilePath,
                                             String signingKeyAlias,
                                             String signingKeyPassword) throws IOException, NoSuchProviderException, KeyStoreException, CertificateException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        return loadSigningKey(new FileInputStream(pkcs12KeyFilePath), signingKeyAlias, signingKeyPassword);
+    }
+    /**
+     * Load a RSA signing key out of a PKCS#12 container.
+     */
+    public static PrivateKey loadSigningKey(InputStream pkcs12KeyInputStream,
+                                            String signingKeyAlias,
+                                            String signingKeyPassword) throws IOException, NoSuchProviderException, KeyStoreException, CertificateException, NoSuchAlgorithmException, UnrecoverableKeyException {
         KeyStore pkcs12KeyStore = KeyStore.getInstance("PKCS12", "SunJSSE");
-        pkcs12KeyStore.load(new FileInputStream(pkcs12KeyFilePath), signingKeyPassword.toCharArray());
+        pkcs12KeyStore.load(pkcs12KeyInputStream, signingKeyPassword.toCharArray());
         return (PrivateKey) pkcs12KeyStore.getKey(signingKeyAlias, signingKeyPassword.toCharArray());
     }
 }


### PR DESCRIPTION
It is possible to load a file (as an input stream) from different sources (in spring using the @Resource annotation). It is good to refactor the util method so it can either read the key from path or from an InputStream.