### PR TITLE
Fix for https://github.com/Mastercard/oauth1-signer-java/issues/18

### DIFF
--- a/src/main/java/com/mastercard/developer/oauth/OAuth.java
+++ b/src/main/java/com/mastercard/developer/oauth/OAuth.java
@@ -1,7 +1,6 @@
 package com.mastercard.developer.oauth;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.security.*;
 import java.util.Arrays;

--- a/src/main/java/com/mastercard/developer/oauth/OAuth.java
+++ b/src/main/java/com/mastercard/developer/oauth/OAuth.java
@@ -224,12 +224,7 @@ public class OAuth {
       path = "/";
     }
 
-    try {
-      // Remove query and fragment
-      return new URI(scheme, authority, path, null, null).toString();
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException("Unable to normalize provided URL due to: " + e.getMessage());
-    }
+    return scheme + "://" + authority + path;
   }
 
   /**

--- a/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
+++ b/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
@@ -211,14 +211,14 @@ public class OAuthTest {
   }
 
   @Test
-  public void testGetBaseUriString_ShouldNotEncodePathParams() {
+  public void testGetBaseUriString_ShouldNotEncodePathSegments() {
     URI uri = URI.create("https://www.example.net:8080/foo@bar/test?query=test");
     String baseUri = OAuth.getBaseUriString(uri);
     assertEquals("https://www.example.net:8080/foo@bar/test", baseUri);
   }
 
   @Test
-  public void testGetBaseUriString_ShouldNotDoubleEncodePathParams() {
+  public void testGetBaseUriString_ShouldNotDoubleEncodePathSegments() {
     URI uri = URI.create("https://www.example.net:8080/foo%40bar/test?query=test");
     String baseUri = OAuth.getBaseUriString(uri);
     assertEquals("https://www.example.net:8080/foo%40bar/test", baseUri);

--- a/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
+++ b/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
@@ -211,20 +211,6 @@ public class OAuthTest {
   }
 
   @Test
-  public void testGetBaseUriString_ShouldNotEncodePathSegments() {
-    URI uri = URI.create("https://www.example.net:8080/foo@bar/test?query=test");
-    String baseUri = OAuth.getBaseUriString(uri);
-    assertEquals("https://www.example.net:8080/foo@bar/test", baseUri);
-  }
-
-  @Test
-  public void testGetBaseUriString_ShouldNotDoubleEncodePathSegments() {
-    URI uri = URI.create("https://www.example.net:8080/foo%40bar/test?query=test");
-    String baseUri = OAuth.getBaseUriString(uri);
-    assertEquals("https://www.example.net:8080/foo%40bar/test", baseUri);
-  }
-
-  @Test
   public void testGetBaseUriString_ShouldRemoveRedundantPorts() {
     URI uri = URI.create("https://api.mastercard.com:443/test?query=param");
     String baseUri = OAuth.getBaseUriString(uri);
@@ -262,13 +248,36 @@ public class OAuthTest {
 
   @Test
   public void testGetBaseUriString_ShouldNotNormalizeEncodedChars() {
-    URI uri = URI.create("https://api.mastercard.com/service/api/test%40test");
+    URI uri = URI.create("https://www.example.com/api/test%40test");
     String baseUri = OAuth.getBaseUriString(uri);
-    assertEquals("https://api.mastercard.com/service/api/test%40test", baseUri);
+    assertEquals("https://www.example.com/api/test%40test", baseUri);
 
     uri = URI.create("http://example.com/r%20v/X?id=123");
     baseUri = OAuth.getBaseUriString(uri);
     assertEquals("http://example.com/r%20v/X", baseUri);
+
+    uri = URI.create("http://example.com/r%2540v/X?id=123");
+    baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("http://example.com/r%2540v/X", baseUri);
+  }
+
+  @Test
+  public void testGetBaseUriString_ShouldNotEncodePathSegments() {
+    URI uri = URI.create("https://www.example.net:8080/foo@bar/test?query=test");
+    String baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://www.example.net:8080/foo@bar/test", baseUri);
+
+    uri = URI.create("https://www.example.net:8080/foo&bar/test?query=test");
+    baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://www.example.net:8080/foo&bar/test", baseUri);
+
+    uri = URI.create("https://www.example.net:8080/foo(bar/test?query=test");
+    baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://www.example.net:8080/foo(bar/test", baseUri);
+
+    uri = URI.create("https://www.example.net:8080/foo=bar/test?query=test");
+    baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://www.example.net:8080/foo=bar/test", baseUri);
   }
 
   @Test

--- a/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
+++ b/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
@@ -204,6 +204,7 @@ public class OAuthTest {
     String baseUri = OAuth.getBaseUriString(uri);
     assertEquals("https://www.example.net:8080/", baseUri);
 
+    // https://tools.ietf.org/html/rfc5849#section-3.4.1.2
     uri = URI.create("http://EXAMPLE.COM:80/r%20v/X?id=123");
     baseUri = OAuth.getBaseUriString(uri);
     assertEquals("http://example.com/r%20v/X", baseUri);

--- a/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
+++ b/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
@@ -206,8 +206,7 @@ public class OAuthTest {
 
     uri = URI.create("http://EXAMPLE.COM:80/r%20v/X?id=123");
     baseUri = OAuth.getBaseUriString(uri);
-    // /!\ According to https://tools.ietf.org/html/rfc5849#section-3.4.1.2 it seems we should get "r%20v", not "r%2520v"
-    assertEquals("http://example.com/r%2520v/X", baseUri);
+    assertEquals("http://example.com/r%20v/X", baseUri);
   }
 
   @Test
@@ -244,6 +243,17 @@ public class OAuthTest {
     URI uri = URI.create("HTTPS://API.MASTERCARD.COM/TEST");
     String baseUri = OAuth.getBaseUriString(uri);
     assertEquals("https://api.mastercard.com/TEST", baseUri);
+  }
+
+  @Test
+  public void testGetBaseUriString_ShouldNotNormalizeEncodedChars() {
+    URI uri = URI.create("https://api.mastercard.com/service/api/test%40test");
+    String baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://api.mastercard.com/service/api/test%40test", baseUri);
+
+    uri = URI.create("http://example.com/r%20v/X?id=123");
+    baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("http://example.com/r%20v/X", baseUri);
   }
 
   @Test

--- a/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
+++ b/src/test/java/com/mastercard/developer/oauth/OAuthTest.java
@@ -211,6 +211,20 @@ public class OAuthTest {
   }
 
   @Test
+  public void testGetBaseUriString_ShouldNotEncodePathParams() {
+    URI uri = URI.create("https://www.example.net:8080/foo@bar/test?query=test");
+    String baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://www.example.net:8080/foo@bar/test", baseUri);
+  }
+
+  @Test
+  public void testGetBaseUriString_ShouldNotDoubleEncodePathParams() {
+    URI uri = URI.create("https://www.example.net:8080/foo%40bar/test?query=test");
+    String baseUri = OAuth.getBaseUriString(uri);
+    assertEquals("https://www.example.net:8080/foo%40bar/test", baseUri);
+  }
+
+  @Test
   public void testGetBaseUriString_ShouldRemoveRedundantPorts() {
     URI uri = URI.create("https://api.mastercard.com:443/test?query=param");
     String baseUri = OAuth.getBaseUriString(uri);


### PR DESCRIPTION
- Fix issue: #18 *(Wrong base URI string is calculated when the provided URI contains url-encoded characters)*
- Build passing [here](https://travis-ci.org/github/Mastercard/oauth1-signer-java/builds/662207161)

