### PR TITLE
Bumping version of httpclient for CVE-2020-13956

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
+            <version>4.5.13</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
#### Description
Bumping the version of HttpClient. It's provided, but still showing up in the dependabot weekly reviews.