### PR TITLE
Spring Web vulnerable to Open Redirect or Server Side Request Forgery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>oauth1-signer</name>
 
     <properties>
-        <spring-version>5.3.3</spring-version>
+        <spring-version>5.3.32</spring-version>
         <okhttp2-version>2.7.5</okhttp2-version>
         <okhttp3-version>4.12.0</okhttp3-version>
         <google-api-client-version>2.3.0</google-api-client-version>


### PR DESCRIPTION
Package
Affected versions
Patched version
org.springframework:spring-web
(Maven)
>= 5.3.0, < 5.3.32
5.3.32
Applications that use UriComponentsBuilder to parse an externally provided URL (e.g. through a query parameter) AND perform validation checks on the host of the parsed URL may be vulnerable to a open redirect attack or to a SSRF attack if the URL is used after passing validation checks.

<!-- Please check the completed items below -->
### PR checklist

- [ ] An issue/feature request has been created for this PR
- [ ] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [ ] File the PR against the `master` branch
- [ ] The code in this PR is covered by unit tests

#### Link to issue/feature request: *add the link here*

#### Description
A clear and concise description of what is this PR for and any additional info might be useful for reviewing it.
