### PR TITLE
spring-web upgrade to 5.3.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>oauth1-signer</name>
 
     <properties>
-        <spring-version>6.0.0</spring-version>
+        <spring-version>5.3.33</spring-version>
         <okhttp2-version>2.7.5</okhttp2-version>
         <okhttp3-version>4.12.0</okhttp3-version>
         <google-api-client-version>2.3.0</google-api-client-version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>oauth1-signer</name>
 
     <properties>
-        <spring-version>5.3.32</spring-version>
+        <spring-version>6.0.0</spring-version>
         <okhttp2-version>2.7.5</okhttp2-version>
         <okhttp3-version>4.12.0</okhttp3-version>
         <google-api-client-version>2.3.0</google-api-client-version>


### PR DESCRIPTION
Upgrading spring-web version to 5.3.33 to address Spring Framework URL Parsing with Host Validation Vulnerability. More here: https://github.com/Mastercard/oauth1-signer-java/security/dependabot/4
Currently cannot upgrade to spring-web 6.0.0 since it is incomptabile with Java 11.
