### PR TITLE
Downgrading webflux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <spring-version>5.3.33</spring-version>
-        <spring-webflux-version>3.5.3</spring-webflux-version>
+        <spring-webflux-version>3.2.12</spring-webflux-version>
         <okhttp2-version>2.7.5</okhttp2-version>
         <okhttp3-version>4.12.0</okhttp3-version>
         <google-api-client-version>2.3.0</google-api-client-version>


### PR DESCRIPTION
Fixing GA by downgrading webflux to a version supported by Java 11